### PR TITLE
fix(getObject): handle when `boundaryMatches` is undefined

### DIFF
--- a/src/actions/getObjectAction.ts
+++ b/src/actions/getObjectAction.ts
@@ -38,7 +38,7 @@ export const getObjectAction =
       : false
     const boundaryMatches = responseHeaders['content-type'].match(/boundary=([^;]+);/)
     const boundary =
-      isMultipart && boundaryMatches.length > 0 ? Buffer.from(boundaryMatches[1]) : Buffer.from('')
+      isMultipart && boundaryMatches?.[1] ? Buffer.from(boundaryMatches[1]) : Buffer.from('')
     const boundaryPrefix = Buffer.from('--')
 
     const objectParser = new ObjectParser({


### PR DESCRIPTION
```
multipart/parallel; boundary=rets.object.content.boundary.1721839732723
```

```shell
ERROR:: TypeError: Cannot read properties of null (reading 'length')
```